### PR TITLE
Remove taint support

### DIFF
--- a/ext/dbm/dbm.c
+++ b/ext/dbm/dbm.c
@@ -279,12 +279,11 @@ fdbm_fetch(VALUE obj, VALUE keystr, VALUE ifnone)
       not_found:
 	if (NIL_P(ifnone) && rb_block_given_p()) {
 	    keystr = rb_str_dup(keystr);
-	    OBJ_TAINT(keystr);
 	    return rb_yield(keystr);
 	}
 	return ifnone;
     }
-    return rb_tainted_str_new(value.dptr, value.dsize);
+    return rb_str_new(value.dptr, value.dsize);
 }
 
 /*
@@ -344,7 +343,7 @@ fdbm_key(VALUE obj, VALUE valstr)
 	val = dbm_fetch(dbm, key);
 	if ((long)val.dsize == RSTRING_LEN(valstr) &&
 	    memcmp(val.dptr, RSTRING_PTR(valstr), val.dsize) == 0) {
-	    return rb_tainted_str_new(key.dptr, key.dsize);
+	    return rb_str_new(key.dptr, key.dsize);
 	}
     }
     return Qnil;
@@ -377,8 +376,8 @@ fdbm_select(VALUE obj)
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	VALUE assoc, v;
 	val = dbm_fetch(dbm, key);
-	assoc = rb_assoc_new(rb_tainted_str_new(key.dptr, key.dsize),
-			     rb_tainted_str_new(val.dptr, val.dsize));
+	assoc = rb_assoc_new(rb_str_new(key.dptr, key.dsize),
+			     rb_str_new(val.dptr, val.dsize));
 	v = rb_yield(assoc);
 	if (RTEST(v)) {
 	    rb_ary_push(new, assoc);
@@ -446,7 +445,7 @@ fdbm_delete(VALUE obj, VALUE keystr)
     }
 
     /* need to save value before dbm_delete() */
-    valstr = rb_tainted_str_new(value.dptr, value.dsize);
+    valstr = rb_str_new(value.dptr, value.dsize);
 
     if (dbm_delete(dbm, key)) {
 	dbmp->di_size = -1;
@@ -481,8 +480,8 @@ fdbm_shift(VALUE obj)
     key = dbm_firstkey(dbm);
     if (!key.dptr) return Qnil;
     val = dbm_fetch(dbm, key);
-    keystr = rb_tainted_str_new(key.dptr, key.dsize);
-    valstr = rb_tainted_str_new(val.dptr, val.dsize);
+    keystr = rb_str_new(key.dptr, key.dsize);
+    valstr = rb_str_new(val.dptr, val.dsize);
     dbm_delete(dbm, key);
 
     return rb_assoc_new(keystr, valstr);
@@ -514,9 +513,9 @@ fdbm_delete_if(VALUE obj)
 
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	keystr = rb_tainted_str_new(key.dptr, key.dsize);
+	keystr = rb_str_new(key.dptr, key.dsize);
 	OBJ_FREEZE(keystr);
-	valstr = rb_tainted_str_new(val.dptr, val.dsize);
+	valstr = rb_str_new(val.dptr, val.dsize);
         ret = rb_protect(rb_yield, rb_assoc_new(rb_str_dup(keystr), valstr), &status);
         if (status != 0) break;
 	if (RTEST(ret)) rb_ary_push(ary, keystr);
@@ -583,8 +582,8 @@ fdbm_invert(VALUE obj)
     GetDBM2(obj, dbmp, dbm);
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	keystr = rb_tainted_str_new(key.dptr, key.dsize);
-	valstr = rb_tainted_str_new(val.dptr, val.dsize);
+	keystr = rb_str_new(key.dptr, key.dsize);
+	valstr = rb_str_new(val.dptr, val.dsize);
 	rb_hash_aset(hash, valstr, keystr);
     }
     return hash;
@@ -744,7 +743,7 @@ fdbm_each_value(VALUE obj)
     GetDBM2(obj, dbmp, dbm);
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	rb_yield(rb_tainted_str_new(val.dptr, val.dsize));
+	rb_yield(rb_str_new(val.dptr, val.dsize));
 	GetDBM2(obj, dbmp, dbm);
     }
     return obj;
@@ -767,7 +766,7 @@ fdbm_each_key(VALUE obj)
 
     GetDBM2(obj, dbmp, dbm);
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
-	rb_yield(rb_tainted_str_new(key.dptr, key.dsize));
+	rb_yield(rb_str_new(key.dptr, key.dsize));
 	GetDBM2(obj, dbmp, dbm);
     }
     return obj;
@@ -794,8 +793,8 @@ fdbm_each_pair(VALUE obj)
 
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	keystr = rb_tainted_str_new(key.dptr, key.dsize);
-	valstr = rb_tainted_str_new(val.dptr, val.dsize);
+	keystr = rb_str_new(key.dptr, key.dsize);
+	valstr = rb_str_new(val.dptr, val.dsize);
 	rb_yield(rb_assoc_new(keystr, valstr));
 	GetDBM2(obj, dbmp, dbm);
     }
@@ -821,7 +820,7 @@ fdbm_keys(VALUE obj)
 
     ary = rb_ary_new();
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
-	rb_ary_push(ary, rb_tainted_str_new(key.dptr, key.dsize));
+	rb_ary_push(ary, rb_str_new(key.dptr, key.dsize));
     }
 
     return ary;
@@ -845,7 +844,7 @@ fdbm_values(VALUE obj)
     ary = rb_ary_new();
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	rb_ary_push(ary, rb_tainted_str_new(val.dptr, val.dsize));
+	rb_ary_push(ary, rb_str_new(val.dptr, val.dsize));
     }
 
     return ary;
@@ -931,8 +930,8 @@ fdbm_to_a(VALUE obj)
     ary = rb_ary_new();
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	rb_ary_push(ary, rb_assoc_new(rb_tainted_str_new(key.dptr, key.dsize),
-				      rb_tainted_str_new(val.dptr, val.dsize)));
+	rb_ary_push(ary, rb_assoc_new(rb_str_new(key.dptr, key.dsize),
+				      rb_str_new(val.dptr, val.dsize)));
     }
 
     return ary;
@@ -957,8 +956,8 @@ fdbm_to_hash(VALUE obj)
     hash = rb_hash_new();
     for (key = dbm_firstkey(dbm); key.dptr; key = dbm_nextkey(dbm)) {
 	val = dbm_fetch(dbm, key);
-	rb_hash_aset(hash, rb_tainted_str_new(key.dptr, key.dsize),
-		           rb_tainted_str_new(val.dptr, val.dsize));
+	rb_hash_aset(hash, rb_str_new(key.dptr, key.dsize),
+		           rb_str_new(val.dptr, val.dsize));
     }
 
     return hash;

--- a/test/dbm/test_dbm.rb
+++ b/test/dbm/test_dbm.rb
@@ -63,7 +63,6 @@ if defined? DBM
       result = Object.new
       assert_same(result, @dbm_rdonly.fetch("bar") {|k| notfound = k; result})
       assert_equal("bar", notfound)
-      assert_predicate(notfound, :tainted?)
     end
   end
 


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
The lack of taint support should not cause a problem in
previous Ruby versions.